### PR TITLE
tests: split ldap validation into separate helper, test validation re…

### DIFF
--- a/app/services/ldap.rb
+++ b/app/services/ldap.rb
@@ -56,7 +56,6 @@ class Ldap
       Response Code: #{ldap_connection.get_operation_result.code}
       Message: #{ldap_connection.get_operation_result.message}
     MESSAGE
-
     raise msg unless ldap_connection.get_operation_result.code.zero?
   end
 

--- a/spec/support/ldap.rb
+++ b/spec/support/ldap.rb
@@ -10,6 +10,9 @@ end
 def mock_ldap_connection
   fake_ldap_connection = double("MockLDAP")
   allow(Ldap).to receive(:ldap_connection).and_return(fake_ldap_connection)
-  allow(Ldap).to receive(:validate_ldap_response).and_return(nil)
   fake_ldap_connection
+end
+
+def mock_ldap_validation
+  allow(Ldap).to receive(:validate_ldap_response).and_return(nil)
 end


### PR DESCRIPTION
…sponses

Fixes #32 

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?

#### What does this PR do?

Adds testing for execution paths of the `validate_ldap_response` method

##### Why are we doing this? Any context of related work?
#32 
